### PR TITLE
[codex] Align CI runtime with test dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -51,7 +51,7 @@ jobs:
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/fetch-menu.yml
+++ b/.github/workflows/fetch-menu.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Fetch menu data
         run: node scripts/fetch-menu.js

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm test          # run regression tests
 npm run build     # build for production → dist/
 ```
 
-Requires Node.js 18+.
+Requires Node.js 20.19+ locally. GitHub Actions runs Node.js 22.
 
 Deployment is automated via GitHub Actions:
 - **Menu data:** `scripts/fetch-menu.js` runs daily at 6 AM ET, fetches latest data, and pushes to `main`

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "scripts": {
     "dev": "vite",
     "generate-icons": "node scripts/generate-icons.js",


### PR DESCRIPTION
## Summary
- update GitHub Actions workflows to run on Node.js 22
- declare the repo's minimum Node version requirement in package metadata
- update README runtime guidance to match the test/build toolchain

## Why
The first PR introduced a test stack whose dependency chain requires Node 20+, but the workflows were still running on Node 18. That caused the PR's `validate` job to fail before tests even started.

## Validation
- npm run typecheck
- npm test
- npm run build