### PR TITLE
Harden GitHub Actions and dedupe main-branch deploy flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
@@ -31,4 +31,5 @@ jobs:
         run: npm test
 
       - name: Build
+        if: github.event_name == 'pull_request'
         run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
 name: Build and Deploy
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
   workflow_dispatch:
 
 concurrency:
@@ -11,43 +12,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Test
-        run: npm test
-
-      - name: Build
-        run: npm run build
-
   build-and-deploy:
-    needs: validate
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout workflow_run commit
+        if: github.event_name == 'workflow_run'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Checkout manual ref
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/.github/workflows/fetch-menu.yml
+++ b/.github/workflows/fetch-menu.yml
@@ -16,10 +16,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:


### PR DESCRIPTION
## Summary
- pin `actions/checkout` and `actions/setup-node` to immutable SHAs in all workflows
- remove duplicate main-branch validation/build work by triggering deploy from CI completion instead of a second push pipeline
- keep PR build validation in CI while leaving deploy to build and publish only after successful CI on `main`

## Details
- `ci.yml` now pins action SHAs and only runs `npm run build` for pull requests
- `deploy.yml` now runs on `workflow_run` from the `CI` workflow plus manual dispatch, and deploys the exact `head_sha` that passed CI on `main`
- `fetch-menu.yml` now pins the same action SHAs for workflow hardening

## Why
This keeps the already-fixed app code untouched while addressing the remaining operational items:
- immutable action references instead of floating tags
- no duplicate main-branch validate/test/build work across CI and deploy
