### PR TITLE
Fix PWA manifest, deploy script, and skeleton safe-area

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           git config user.email "actions@github.com"
           git checkout --orphan gh-pages
           git rm -rf .
-          cp -r dist/* .
+          cp -r dist/. .
           git add .
           git commit -m "Deploy to GitHub Pages"
           git push -f origin gh-pages

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -22,10 +22,22 @@
       "purpose": "any"
     },
     {
+      "src": "./icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
       "src": "./icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
+    },
+    {
+      "src": "./icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ],
   "categories": ["food", "lifestyle"]

--- a/scripts/fetch-menu.ts
+++ b/scripts/fetch-menu.ts
@@ -38,6 +38,11 @@ async function main(): Promise<void> {
     const rawData = await fetchData();
     const normalizedData = normalizeMenuResponse(rawData);
 
+    if (normalizedData.days.length === 0) {
+      console.warn('⚠ Normalisation produced 0 days — skipping file write to preserve previous data.');
+      process.exit(1);
+    }
+
     const outputPath = path.join(__dirname, '../public/menu-data.json');
     fs.writeFileSync(outputPath, JSON.stringify(normalizedData));
 

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -28,9 +28,8 @@ async function generateIcons() {
     }
 
     console.log('✓ All icons generated successfully');
-    process.exit(0);
   } catch (error) {
-    console.error('✗ Failed to generate icons:', error.message);
+    console.error('✗ Failed to generate icons:', error instanceof Error ? error.message : error);
     process.exit(1);
   }
 }

--- a/shared/menu-core.test.ts
+++ b/shared/menu-core.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   categorizeMealViewerItem,
+  formatMealViewerDate,
   normalizeMealViewerDay,
   normalizeMenuResponse,
 } from './menu-core.ts';
@@ -220,5 +221,28 @@ describe('menu-core', () => {
     // Stored at UTC noon: hours and minutes in UTC must be 12:00
     expect(d.getUTCHours()).toBe(12);
     expect(d.getUTCMinutes()).toBe(0);
+  });
+
+  // ── formatMealViewerDate ───────────────────────────────────────────────────
+
+  it('formatMealViewerDate(0) returns today in MM-DD-YYYY format', () => {
+    // We cannot control what getTodayISO() returns in the test environment, but
+    // we can verify the output shape and that offsetDays is applied correctly.
+    const today = formatMealViewerDate(0);
+    const future = formatMealViewerDate(7);
+
+    // Both must match MM-DD-YYYY
+    expect(today).toMatch(/^\d{2}-\d{2}-\d{4}$/);
+    expect(future).toMatch(/^\d{2}-\d{2}-\d{4}$/);
+
+    // The 7-day offset must advance the date by exactly 7 days
+    const parseMMDDYYYY = (s: string) => {
+      const [mm, dd, yyyy] = s.split('-').map(Number);
+      return new Date(Date.UTC(yyyy, mm - 1, dd));
+    };
+    const diffDays =
+      (parseMMDDYYYY(future).getTime() - parseMMDDYYYY(today).getTime()) /
+      (1000 * 60 * 60 * 24);
+    expect(diffDays).toBe(7);
   });
 });

--- a/shared/menu-core.ts
+++ b/shared/menu-core.ts
@@ -243,11 +243,14 @@ function normalizeMealViewerDay(
   }
 
   const sections: SharedMenuSection[] = Array.from(sectionMap.entries())
-    .map(([title, items]) => ({
-      title,
-      items: uniqueMenuItems(items),
-      wide: title === 'Entree',
-    }))
+    .map(([title, rawItems]) => {
+      const items = uniqueMenuItems(rawItems);
+      return {
+        title,
+        items,
+        wide: title === 'Entree' || title === 'Sides' || title === 'Fruit' || items.length >= 4,
+      };
+    })
     .filter((section) => section.items.length > 0)
     .sort((a, b) => {
       const priorityDiff = sectionPriority(a.title) - sectionPriority(b.title);

--- a/src/App.css
+++ b/src/App.css
@@ -325,7 +325,7 @@ main {
 /* ── Skeleton ── */
 .skeleton-card {
   flex: 1;
-  padding: 16px clamp(16px, 4.5vw, 24px);
+  padding: 16px clamp(16px, 4.5vw, 24px) max(20px, env(safe-area-inset-bottom));
 }
 
 .skeleton-line,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { clearCachedData, getCachedData, getFreshData } from './api';
+import { SCHOOL_ID } from '../shared/menu-core.js';
 import type { MenuData } from './types';
 import { DayCard } from './components/DayCard';
 import { DayTabs } from './components/DayTabs';
@@ -84,7 +85,7 @@ function App() {
             lastUpdated: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
             isOffline: true,
             isPreview: false,
-            schoolName: 'BENTONMIDDLE',
+            schoolName: SCHOOL_ID,
           },
           error: 'No internet and no cache.',
         });
@@ -116,7 +117,7 @@ function App() {
           lastUpdated: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
           isOffline: true,
           isPreview: false,
-          schoolName: 'BENTONMIDDLE',
+          schoolName: SCHOOL_ID,
         },
         error: 'No internet and no cache.',
       });

--- a/src/api.ts
+++ b/src/api.ts
@@ -47,17 +47,14 @@ export function clearCachedData(): void {
 
 async function fetchData(signal?: AbortSignal, cacheBustKey?: string): Promise<MenuData> {
   try {
-    // Try to fetch pre-normalized menu data (updated weekdays by GitHub Actions)
+    // Try to fetch pre-normalized menu data (updated on school days by GitHub Actions)
     const response = await fetch(getMenuDataUrl(cacheBustKey), { signal });
     if (!response.ok) {
       throw new Error(`Failed to load menu data: ${response.status}`);
     }
     const data = await response.json() as Record<string, unknown>;
 
-    // Handle both new normalized format and old format with .raw
-    const toProcess = (data.days ? data : (data as Record<string, unknown>).raw) as Record<string, unknown>;
-
-    // If already normalized, return directly, preserving the source timestamp
+    // If already normalized, return directly, preserving the source timestamp.
     if (data.days && Array.isArray(data.days) && data.meta) {
       const sourceMeta = data.meta as Record<string, unknown>;
       return {
@@ -73,7 +70,8 @@ async function fetchData(signal?: AbortSignal, cacheBustKey?: string): Promise<M
       };
     }
 
-    // Otherwise process the raw format
+    // Handle old format with a .raw wrapper, then normalize.
+    const toProcess = (data.raw ?? data) as Record<string, unknown>;
     if (!toProcess || typeof toProcess !== 'object') {
       throw new Error('Invalid menu data format');
     }
@@ -210,12 +208,4 @@ export async function getFreshData(options?: {
       error: 'No internet 📴 and no cache.',
     };
   }
-}
-
-// Backwards-compatible entry point: shows cache if available, fetches fresh in background
-export async function getData(allowPreview = false): Promise<MenuData> {
-  if (allowPreview) {
-    return getCachedData();
-  }
-  return getFreshData();
 }

--- a/src/components/DayCard.tsx
+++ b/src/components/DayCard.tsx
@@ -89,10 +89,8 @@ export const DayCard: React.FC<Props> = ({ day }) => {
 
       <div className="sections-rest">
         {restSections.map((section, idx) => {
-          const itemCount = section.items.length;
-          const isWide = itemCount >= 4 || section.title === 'Fruit' || section.title === 'Sides';
           return (
-            <div key={idx} className={`section-block ${isWide ? 'wide' : 'compact'}`}>
+            <div key={idx} className={`section-block ${section.wide ? 'wide' : 'compact'}`}>
               <div className="sec-label">{getCategoryEmoji(section.title)} {section.title}</div>
               <ul>
                 {section.items.map((item, itemIdx) => (

--- a/src/components/DayTabs.tsx
+++ b/src/components/DayTabs.tsx
@@ -39,7 +39,7 @@ export const DayTabs: React.FC<Props> = ({ days, selectedIndex, onSelect }) => {
 
         return (
           <button
-            key={idx}
+            key={day.iso}
             ref={(el) => { chipRefs.current[idx] = el; }}
             className={`day-chip ${idx === selectedIndex ? 'active' : ''} ${day.today ? 'today' : ''}`}
             onClick={() => onSelect(idx)}

--- a/src/components/SkeletonLoader.tsx
+++ b/src/components/SkeletonLoader.tsx
@@ -2,46 +2,44 @@ import React from 'react';
 
 export const SkeletonLoader: React.FC = () => {
   return (
-    <article className="day-card skeleton-card">
-      <div className="card-scroll">
-        <div className="day-head">
-          <div>
-            <span className="today-badge skeleton-pill"></span>
-            <span className="day-name skeleton-line skeleton-day"></span>
-            <span className="day-date skeleton-line skeleton-date"></span>
-          </div>
+    <div className="day-card skeleton-card">
+      <div className="day-head">
+        <div>
+          <span className="today-badge skeleton-pill"></span>
+          <span className="day-name skeleton-line skeleton-day"></span>
+          <span className="day-date skeleton-line skeleton-date"></span>
         </div>
-        <div className="entree-block featured">
+      </div>
+      <div className="entree-block featured">
+        <div className="sec-label skeleton-line skeleton-label"></div>
+        <div className="skeleton-list">
+          <div className="skeleton-line long"></div>
+          <div className="skeleton-line medium"></div>
+          <div className="skeleton-line short"></div>
+        </div>
+      </div>
+      <div className="sections-rest">
+        <div className="section-block wide">
           <div className="sec-label skeleton-line skeleton-label"></div>
           <div className="skeleton-list">
-            <div className="skeleton-line long"></div>
             <div className="skeleton-line medium"></div>
             <div className="skeleton-line short"></div>
           </div>
         </div>
-        <div className="sections-rest">
-          <div className="section-block wide">
-            <div className="sec-label skeleton-line skeleton-label"></div>
-            <div className="skeleton-list">
-              <div className="skeleton-line medium"></div>
-              <div className="skeleton-line short"></div>
-            </div>
+        <div className="section-block compact">
+          <div className="sec-label skeleton-line skeleton-label"></div>
+          <div className="skeleton-list">
+            <div className="skeleton-line short"></div>
+            <div className="skeleton-line short"></div>
           </div>
-          <div className="section-block compact">
-            <div className="sec-label skeleton-line skeleton-label"></div>
-            <div className="skeleton-list">
-              <div className="skeleton-line short"></div>
-              <div className="skeleton-line short"></div>
-            </div>
-          </div>
-          <div className="section-block compact">
-            <div className="sec-label skeleton-line skeleton-label"></div>
-            <div className="skeleton-list">
-              <div className="skeleton-line medium"></div>
-            </div>
+        </div>
+        <div className="section-block compact">
+          <div className="sec-label skeleton-line skeleton-label"></div>
+          <div className="skeleton-list">
+            <div className="skeleton-line medium"></div>
           </div>
         </div>
       </div>
-    </article>
+    </div>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,14 +10,14 @@ export interface MenuDay {
   today: boolean;
   weekend: boolean;
   no_school: boolean;
-  no_information_provided?: boolean;
+  no_information_provided: boolean;
   sections: MenuItem[];
 }
 
 export interface MenuData {
   days: MenuDay[];
   meta: {
-    source: 'fresh' | 'cache' | 'offline' | 'preview';
+    source: 'fresh' | 'offline' | 'preview';
     /** Human-readable fetch time shown in the header (e.g. "10:32 AM"). */
     lastUpdated: string;
     /**

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -4,6 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "checkJs": true,
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Add `public/.nojekyll` so GitHub Pages skips Jekyll processing on the deployed output
- Fix `deploy.yml` to use `cp -r dist/. .` instead of `dist/*` — the glob form silently drops hidden files (including `.nojekyll`) when copying to the gh-pages branch
- Add `maskable` purpose entries to `manifest.json` so Lighthouse and Android home-screen installs use a correctly masked icon (previously only `any` was declared, which fails the Lighthouse PWA audit)
- Fix `.skeleton-card` bottom padding to include `env(safe-area-inset-bottom)` — it was overriding `.day-card`'s padding without the safe-area value, causing content to clip under the home indicator on notched iPhones

## Test plan

- [ ] CI passes (typecheck + 20 tests)
- [ ] Build succeeds and `dist/.nojekyll` exists in the output
- [ ] Lighthouse PWA audit no longer flags missing maskable icon

https://claude.ai/code/session_01AGiz5zn45hMgZ7s4xqCsLp