### PR TITLE
Address principal-engineer audit findings

### DIFF
--- a/.github/workflows/fetch-menu.yml
+++ b/.github/workflows/fetch-menu.yml
@@ -60,8 +60,13 @@ jobs:
           git commit -m "Update menu data via GitHub Actions - $FETCH_TIME"
           git push
 
-      - name: Notify on failure
+      - name: Open issue on failure
         if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "❌ Menu data fetch failed!"
-          exit 1
+          FETCH_TIME=$(date -u +'%Y-%m-%d %H:%M UTC')
+          gh issue create \
+            --title "Menu data fetch failed — ${FETCH_TIME}" \
+            --body "The scheduled menu fetch workflow failed at ${FETCH_TIME}. Students may see stale data until this is resolved. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details." \
+          || echo "⚠ Could not create issue; see workflow logs for failure details."

--- a/scripts/fetch-menu.ts
+++ b/scripts/fetch-menu.ts
@@ -75,9 +75,9 @@ async function main(): Promise<void> {
     const rawData = await fetchWithRetry();
     const snapshotGeneratedAt = new Date().toISOString();
     const normalizedData = normalizeMenuResponse(rawData, {
+      snapshotGeneratedAt,
       expectedNextRefreshAt: getExpectedNextRefreshAt(snapshotGeneratedAt),
     });
-    normalizedData.meta.snapshotGeneratedAt = snapshotGeneratedAt;
     const outputPath = path.join(__dirname, '../public/menu-data.json');
     const previousSnapshot = loadPreviousSnapshot(outputPath);
 

--- a/shared/menu-contract.test.ts
+++ b/shared/menu-contract.test.ts
@@ -5,6 +5,7 @@ import {
   isPastExpectedRefresh,
   validateMenuArtifact,
 } from './menu-contract.ts';
+import { PWCS_CALENDAR_COVERAGE_END_ISO } from './pwcs-calendar.ts';
 
 function makeArtifact(overrides: Partial<SharedMenuResponse> = {}): SharedMenuResponse {
   const base: SharedMenuResponse = {
@@ -176,5 +177,30 @@ describe('menu artifact contract', () => {
   it('treats the expected refresh deadline plus grace period as stale', () => {
     expect(isPastExpectedRefresh('2026-04-18T10:00:00.000Z', Date.parse('2026-04-18T11:59:00.000Z'))).toBe(false);
     expect(isPastExpectedRefresh('2026-04-18T10:00:00.000Z', Date.parse('2026-04-18T12:01:00.000Z'))).toBe(true);
+  });
+
+  it('accepts an implausible artifact when enforcePlausibility is disabled', () => {
+    // A single-day artifact would normally fail plausibility, but the cache
+    // loader passes enforcePlausibility:false for previously committed entries.
+    const singleDay = makeArtifact({
+      days: [makeArtifact().days[0]],
+    });
+
+    expect(() =>
+      validateMenuArtifact(singleDay, undefined, { enforcePlausibility: false }),
+    ).not.toThrow();
+  });
+
+  // ── D-1: Calendar coverage advance-warning ────────────────────────────────
+  // This test fails approximately 30 days before the PWCS calendar coverage
+  // cliff, giving a lead-time signal to update pwcs-calendar.ts before the
+  // weekly fetch pipeline breaks silently.
+  it('PWCS_CALENDAR_COVERAGE_END_ISO is at least 30 days in the future', () => {
+    const coverageEnd = Date.parse(`${PWCS_CALENDAR_COVERAGE_END_ISO}T00:00:00Z`);
+    const thirtyDaysFromNow = Date.now() + 30 * 24 * 60 * 60 * 1000;
+    expect(
+      coverageEnd,
+      `PWCS calendar coverage ends ${PWCS_CALENDAR_COVERAGE_END_ISO} — update pwcs-calendar.ts before it expires`,
+    ).toBeGreaterThan(thirtyDaysFromNow);
   });
 });

--- a/shared/menu-contract.ts
+++ b/shared/menu-contract.ts
@@ -28,6 +28,12 @@ const VALID_SECTION_TITLES = new Set([
   'Other',
 ]);
 
+// Title-cased item name → expected section, verified in committed artifacts.
+// IMPORTANT: Keep this list in sync with ITEM_CATEGORY_OVERRIDES in
+// menu-core.ts, which uses the same items (lowercase) to assign sections during
+// normalization.  Adding an entry here without a corresponding entry there will
+// cause validation to reject any artifact that contains the item, since it will
+// have been placed in the wrong section by the normalizer.
 const REQUIRED_ARTIFACT_ITEM_SECTIONS: Record<string, string> = {
   'American Cheese Slice': 'Condiments',
   'Applesauce Cup': 'Fruit',

--- a/shared/menu-core.test.ts
+++ b/shared/menu-core.test.ts
@@ -421,4 +421,60 @@ describe('menu-core', () => {
   it('getNextSchoolDay leaves weekdays unchanged', () => {
     expect(getNextSchoolDay('2026-04-13')).toBe('2026-04-13');
   });
+
+  // ── D-7: getNextSchoolDay intentionally returns PWCS no-school weekdays ───
+  // The function computes the display cutoff (first non-weekend day ≥ fromISO),
+  // NOT the next instructional day.  No-school weekdays still appear in the UI
+  // as "No school" cards, so they must not be skipped here.
+  it('getNextSchoolDay returns a PWCS no-school weekday unchanged (by design)', () => {
+    // 2026-11-02 is a PWCS no-school Monday; getNextSchoolDay must return it so
+    // the "No school" card appears as the first visible day of the week.
+    expect(getNextSchoolDay('2026-11-02')).toBe('2026-11-02');
+  });
+
+  it('getNextSchoolDay on Sunday before a PWCS no-school Monday returns that Monday', () => {
+    // 2026-11-01 is Sunday; displayFromISO should be 2026-11-02 (no-school Mon).
+    expect(getNextSchoolDay('2026-11-01')).toBe('2026-11-02');
+  });
+
+  // ── D-2: isPlausibleMenuSnapshot near end of school year ─────────────────
+  it('accepts a two-day snapshot in the final week of school when the calendar has only two days left', () => {
+    // 2026-06-11 (Thursday) and 2026-06-12 (Friday) are the last two days of
+    // school.  There are exactly 2 instructional days left so the low count is
+    // calendar-justified and the snapshot must be accepted.
+    const result = normalizeMenuResponse(
+      {
+        schoolName: 'TEST',
+        menuSchedules: [
+          makeSchedule('2026-06-11', 'Lunch', PIZZA_ITEMS),
+          makeSchedule('2026-06-12', 'Lunch', PIZZA_ITEMS),
+        ],
+      },
+      { todayISO: '2026-06-11' },
+    );
+
+    expect(isPlausibleMenuSnapshot(result.days, undefined, '2026-06-11')).toBe(true);
+  });
+
+  it('rejects a two-day snapshot with wide gaps when many instructional days are skipped', () => {
+    // Providing only Mon 04/13 and Mon 04/20 (6 instructional days in range,
+    // no PWCS holidays between them) yields 2 visible days despite the gap.
+    // The plausibility check rejects because count (6) >= minimumDays (3) but
+    // only 2 days are present — indicating missing data, not an end-of-year cliff.
+    const result = normalizeMenuResponse(
+      {
+        schoolName: 'TEST',
+        menuSchedules: [
+          makeSchedule('2026-04-13', 'Lunch', PIZZA_ITEMS), // Mon
+          makeSchedule('2026-04-20', 'Lunch', PIZZA_ITEMS), // skip Tue-Fri, next Mon
+        ],
+      },
+      { todayISO: '2026-04-13' },
+    );
+
+    // normalizeMenuResponse does not inject days between Apr 13 and Apr 20
+    // because there are no PWCS no-school weekdays in that span.
+    expect(result.days).toHaveLength(2);
+    expect(isPlausibleMenuSnapshot(result.days, undefined, '2026-04-13')).toBe(false);
+  });
 });

--- a/shared/menu-core.ts
+++ b/shared/menu-core.ts
@@ -60,14 +60,14 @@ export interface SharedMenuResponse {
 
 // ── Date helpers ──────────────────────────────────────────────────────────────
 
-function getFormatter(): Intl.DateTimeFormat {
-  return new Intl.DateTimeFormat('en-US', {
-    timeZone: SCHOOL_TIMEZONE,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-}
+// Module-level singleton: Intl.DateTimeFormat is expensive to construct and
+// safe for concurrent calls, so we reuse a single instance across all callers.
+const schoolDateFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: SCHOOL_TIMEZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
 
 function formatSchoolDate(
   iso: string,
@@ -80,7 +80,7 @@ function formatSchoolDate(
 }
 
 function getTodayISO(): string {
-  const parts = getFormatter().formatToParts(new Date());
+  const parts = schoolDateFormatter.formatToParts(new Date());
   const year = parts.find((part) => part.type === 'year')?.value;
   const month = parts.find((part) => part.type === 'month')?.value;
   const day = parts.find((part) => part.type === 'day')?.value;
@@ -98,6 +98,15 @@ function formatUTCISODate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+/**
+ * Returns the display cutoff date — the first weekday on or after fromISO.
+ *
+ * IMPORTANT: this function advances past Saturdays (+2→Monday) and Sundays
+ * (+1→Monday) ONLY.  It intentionally does NOT skip PWCS no-school weekdays;
+ * those still appear in the UI as "No school" cards.  If you need the next
+ * *actual instructional* day, use countPWCSInstructionalWeekdaysBetween or
+ * consult isPWCSNoSchoolDate after calling this function.
+ */
 function getNextSchoolDay(fromISO: string): string {
   const date = parseISOAtUtcNoon(fromISO);
   const dayOfWeek = date.getUTCDay();
@@ -151,6 +160,14 @@ function isPlausibleMenuSnapshot(
     return false;
   }
 
+  // Reject if too few visible days — but allow a calendar-justified short week.
+  //
+  // Truth table (minimumDays = 3):
+  //   visibleDays.length >= 3           → outer condition false → pass
+  //   visibleDays.length == 2:
+  //     instructional days in window < 3 → inner OR both false → pass (end-of-year)
+  //     instructional days in window >= 3 → inner right true   → fail (missing data)
+  //   visibleDays.length < 2            → inner left true      → always fail
   if (
     visibleDays.length < minimumDays &&
     (
@@ -191,12 +208,6 @@ function formatMealViewerDate(offsetDays = 0): string {
   return `${month}-${day}-${year}`;
 }
 
-function getDefaultExpectedNextRefreshAt(): string {
-  const generatedAt = new Date();
-  generatedAt.setUTCDate(generatedAt.getUTCDate() + 7);
-  return generatedAt.toISOString();
-}
-
 // ── Menu categorisation ───────────────────────────────────────────────────────
 
 function sectionPriority(title: string): number {
@@ -232,6 +243,12 @@ function uniqueMenuItems(items: string[]): string[] {
   return clean;
 }
 
+// Lowercase name → canonical section overrides applied at normalization time.
+// IMPORTANT: Keep this list in sync with REQUIRED_ARTIFACT_ITEM_SECTIONS in
+// menu-contract.ts, which uses the same item names (title-cased) to validate
+// that the built artifact has placed each item in the expected section.  Adding
+// a new entry here without a matching entry there means the override is applied
+// but never verified in the committed artifact.
 const ITEM_CATEGORY_OVERRIDES: Record<string, string> = {
   'american cheese slice': 'Condiments',
   'applesauce cup': 'Fruit',
@@ -403,7 +420,23 @@ function normalizeMealViewerDay(
 
 function normalizeMenuResponse(
   rawData: Record<string, unknown>,
-  options: { expectedNextRefreshAt?: string; todayISO?: string } = {},
+  options: {
+    /**
+     * The ISO timestamp captured immediately before this normalization call.
+     * Must be provided by the caller so that snapshotGeneratedAt and
+     * expectedNextRefreshAt are derived from the same instant.  Falls back to
+     * new Date().toISOString() only in tests; production callers must always
+     * provide this to keep the two timestamps consistent.
+     */
+    snapshotGeneratedAt?: string;
+    /**
+     * Must be the next Saturday 10:00 UTC computed from snapshotGeneratedAt
+     * via getExpectedNextRefreshAt().  Omitting this in production produces an
+     * artifact whose expectedNextRefreshAt is '' and will fail validateMenuArtifact.
+     */
+    expectedNextRefreshAt?: string;
+    todayISO?: string;
+  } = {},
 ): SharedMenuResponse {
   // Use the true calendar today for the "Today" badge so that on weekends no
   // future day is incorrectly labelled "Today".  Separately, compute the first
@@ -444,8 +477,16 @@ function normalizeMenuResponse(
     days,
     meta: {
       schemaVersion: MENU_SCHEMA_VERSION,
-      snapshotGeneratedAt: new Date().toISOString(),
-      expectedNextRefreshAt: options.expectedNextRefreshAt ?? getDefaultExpectedNextRefreshAt(),
+      // Prefer the caller-supplied timestamp so that snapshotGeneratedAt and
+      // expectedNextRefreshAt are derived from the same instant.  The fallback
+      // is intentionally left for test convenience only; production callers in
+      // fetch-menu.ts always pass this option.
+      snapshotGeneratedAt: options.snapshotGeneratedAt ?? new Date().toISOString(),
+      // '' is intentionally invalid: an artifact without a proper Saturday-
+      // aligned expectedNextRefreshAt will fail validateMenuArtifact, making
+      // the missing option visible immediately rather than silently persisting a
+      // bad value.
+      expectedNextRefreshAt: options.expectedNextRefreshAt ?? '',
       schoolName: (rawData?.schoolName as string) || SCHOOL_ID,
     },
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,9 @@ function App() {
   const [loading, setLoading] = useState(true);
   const [retrying, setRetrying] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [themePreference, setThemePreference] = useState<ThemePreference>(() => getInitialThemePreference());
+  const [themePreference, setThemePreference] = useState<ThemePreference>(getInitialThemePreference);
+  // Derive the concrete theme from the same preference: reads localStorage once
+  // via getInitialThemePreference() then converts 'system' to the OS value.
   const [theme, setTheme] = useState<Theme>(() => getInitialTheme(getInitialThemePreference()));
   const retryControllerRef = useRef<AbortController | null>(null);
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,7 @@ import {
 import type { MenuData } from './types';
 
 const CACHE_KEY = `bms_lunch_cache_v${MENU_CACHE_SEMANTIC_VERSION}`;
+const CACHE_KEY_PREFIX = 'bms_lunch_cache_v';
 const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const SNAPSHOT_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // weekly schedule SLA
 const INVALID_SNAPSHOT_MESSAGE = 'Menu snapshot is unavailable right now. Showing the last known good menu.';
@@ -152,7 +153,30 @@ function buildInvalidSnapshotResult(message: string, cached?: CacheEntry | null)
   };
 }
 
+/**
+ * Remove any localStorage entries whose key matches the cache prefix but
+ * belongs to an older semantic version.  On shared/public devices (school
+ * Chromebooks) stale keys would otherwise accumulate indefinitely.
+ */
+function purgeStaleCacheKeys(): void {
+  try {
+    const keysToDelete: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(CACHE_KEY_PREFIX) && key !== CACHE_KEY) {
+        keysToDelete.push(key);
+      }
+    }
+    for (const key of keysToDelete) {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // Ignore storage errors during cleanup.
+  }
+}
+
 function loadCache(): CacheEntry | null {
+  purgeStaleCacheKeys();
   try {
     const cached = localStorage.getItem(CACHE_KEY);
     if (!cached) return null;


### PR DESCRIPTION
## Summary

Addresses the actionable items from the principal/staff-engineer production code review. All changes are non-breaking; 72 tests pass.

- **B-2/B-4** — Pass `snapshotGeneratedAt` into `normalizeMenuResponse` explicitly so both timestamps are derived from the same captured instant. Removes the silent post-call mutation at `fetch-menu.ts:80` and deletes the dead `getDefaultExpectedNextRefreshAt()` function, which produced Saturday-misaligned values that would have caused `validateMenuArtifact` to throw if it were ever activated.
- **B-5** — Replace per-call `Intl.DateTimeFormat` construction inside `getTodayISO()` with a module-level singleton, eliminating repeated locale-data lookup on every render cycle.
- **B-6** — Document the two-call `getInitialThemePreference()` initializer pattern and pass the function reference directly to the first `useState` to remove the wrapping lambda.
- **B-7 / G-5** — Add an inline truth-table comment to the `isPlausibleMenuSnapshot` nested conditional and a JSDoc block to `getNextSchoolDay` clarifying it advances past weekends only — not PWCS no-school weekdays.
- **B-8** — Replace the no-op `echo "❌ …" && exit 1` step in `fetch-menu.yml` with `gh issue create`, so a failed Saturday cron surfaces as a GitHub issue rather than silently expiring in the Actions log.
- **F-3** — Run `purgeStaleCacheKeys()` on every `loadCache()` call to remove leftover `bms_lunch_cache_v*` entries from prior versions on shared/school devices.
- **G-1** — Add cross-reference comments to both `ITEM_CATEGORY_OVERRIDES` (`menu-core.ts`) and `REQUIRED_ARTIFACT_ITEM_SECTIONS` (`menu-contract.ts`) so a new item added to one without the other is caught at review time.
- **D-1** — New test: asserts `PWCS_CALENDAR_COVERAGE_END_ISO` is ≥ 30 days from today. This will start failing in CI approximately one month before the June 2027 pipeline cliff, providing actionable lead time.
- **D-2** — Two new `isPlausibleMenuSnapshot` tests: end-of-school-year two-day acceptance, and wide-gap two-day rejection.
- **D-7** — Two new `getNextSchoolDay` tests documenting the intentional pass-through of PWCS no-school weekdays.
- **D-8** — New test confirming `validateMenuArtifact` with `enforcePlausibility: false` accepts a single-day snapshot (the cache-load path).

## Remaining open item

**B-1 (calendar expiry)** — Adding 2027-28 PWCS no-school dates to `pwcs-calendar.ts` requires the official published calendar and is tracked by the new D-1 advance-warning test, which will fail ~30 days before the cliff.

## Test plan

- [x] `npm test` — 72/72 passing
- [x] `npm run typecheck` — clean
- [ ] Merge when CI is green

https://claude.ai/code/session_01AGiz5zn45hMgZ7s4xqCsLp