### PR TITLE
Third-round audit fixes: plausibility, dedup, guards, docs

### DIFF
--- a/.github/workflows/fetch-menu.yml
+++ b/.github/workflows/fetch-menu.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5

--- a/.github/workflows/fetch-menu.yml
+++ b/.github/workflows/fetch-menu.yml
@@ -59,6 +59,7 @@ jobs:
           git add public/menu-data.json
           FETCH_TIME=$(date -u +'%Y-%m-%d %H:%M:%S UTC')
           git commit -m "Update menu data via GitHub Actions - $FETCH_TIME"
+          git pull --rebase origin main
           git push
 
       - name: Open issue on failure

--- a/scripts/fetch-menu.ts
+++ b/scripts/fetch-menu.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import {
   formatMealViewerDate,
-  isPlausibleMenuSnapshot,
   normalizeMenuResponse,
   SCHOOL_ID,
   type SharedMenuResponse,
@@ -86,11 +85,8 @@ async function main(): Promise<void> {
       process.exit(1);
     }
 
-    if (!isPlausibleMenuSnapshot(normalizedData.days, previousSnapshot?.days)) {
-      console.warn('⚠ Normalised snapshot failed plausibility checks — preserving previous artifact.');
-      process.exit(1);
-    }
-
+    // validateMenuArtifact runs isPlausibleMenuSnapshot internally; no need for
+    // a separate pre-flight call.
     validateMenuArtifact(normalizedData, previousSnapshot?.days);
 
     fs.writeFileSync(outputPath, JSON.stringify(normalizedData));

--- a/scripts/fetch-menu.ts
+++ b/scripts/fetch-menu.ts
@@ -16,6 +16,7 @@ const __dirname = path.dirname(__filename);
 
 const API_BASE_URL = 'https://api.mealviewer.com/api/v4/school';
 const MAX_FETCH_ATTEMPTS = 3;
+const FETCH_TIMEOUT_MS = 30_000; // 30 s per attempt; prevents a hung connection blocking the runner
 
 function loadPreviousSnapshot(outputPath: string): SharedMenuResponse | null {
   try {
@@ -36,16 +37,24 @@ async function fetchData(): Promise<Record<string, unknown>> {
 
   console.log(`Fetching menu data from: ${url}`);
 
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: { 'Content-Type': 'application/json' },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  if (!response.ok) {
-    throw new Error(`API error: ${response.status}`);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    return await (response.json() as Promise<Record<string, unknown>>);
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  return response.json() as Promise<Record<string, unknown>>;
 }
 
 async function fetchWithRetry(): Promise<Record<string, unknown>> {
@@ -88,6 +97,24 @@ async function main(): Promise<void> {
     // validateMenuArtifact runs isPlausibleMenuSnapshot internally; no need for
     // a separate pre-flight call.
     validateMenuArtifact(normalizedData, previousSnapshot?.days);
+
+    if (previousSnapshot !== null) {
+      const instructionalDays = normalizedData.days.filter((d) => !d.weekend && !d.no_school);
+      const noInfoCount = instructionalDays.filter((d) => d.no_information_provided).length;
+      const noInfoRate = instructionalDays.length > 0 ? noInfoCount / instructionalDays.length : 0;
+      const prevInstructionalDays = previousSnapshot.days.filter((d) => !d.weekend && !d.no_school);
+      const prevNoInfoCount = prevInstructionalDays.filter((d) => d.no_information_provided).length;
+      const prevNoInfoRate = prevInstructionalDays.length > 0 ? prevNoInfoCount / prevInstructionalDays.length : 0;
+      if (noInfoRate > 0.5 && noInfoRate - prevNoInfoRate > 0.4) {
+        console.warn(
+          `⚠ High no-information rate: ${noInfoCount}/${instructionalDays.length} school days` +
+          ` (${(noInfoRate * 100).toFixed(0)}%) have no menu data,` +
+          ` up from ${(prevNoInfoRate * 100).toFixed(0)}% in the previous snapshot.` +
+          ' Skipping file write to preserve previous data.',
+        );
+        process.exit(1);
+      }
+    }
 
     fs.writeFileSync(outputPath, JSON.stringify(normalizedData));
 

--- a/shared/menu-contract.ts
+++ b/shared/menu-contract.ts
@@ -280,8 +280,17 @@ function validateSectionFamilies(data: SharedMenuResponse): void {
 
 function validateOfficialNoSchoolDays(data: SharedMenuResponse): void {
   const daysByIso = new Map(data.days.map((day) => [day.iso, day]));
-  const firstISO = data.days[0]?.iso;
-  const lastISO = data.days[data.days.length - 1]?.iso;
+  // Use reduce rather than data.days[0] / data.days[last] because the artifact
+  // is sorted today-first (the current day floats to index 0), which means
+  // array positions do not reflect chronological order.
+  const firstISO = data.days.reduce<string | undefined>(
+    (min, day) => (min === undefined || day.iso < min ? day.iso : min),
+    undefined,
+  );
+  const lastISO = data.days.reduce<string | undefined>(
+    (max, day) => (max === undefined || day.iso > max ? day.iso : max),
+    undefined,
+  );
   if (!firstISO || !lastISO) {
     return;
   }

--- a/shared/menu-core.test.ts
+++ b/shared/menu-core.test.ts
@@ -344,24 +344,46 @@ describe('menu-core', () => {
     expect(isPlausibleMenuSnapshot(result.days, undefined, '2026-04-13')).toBe(false);
   });
 
-  it('accepts shorter snapshots versus the previous artifact when the current range is still internally plausible', () => {
+  it('accepts a shorter snapshot at year-end versus the previous artifact when the visible range is near the last school day', () => {
+    // Previous artifact had Jun 8-12 (full final week); the replacement has only
+    // Jun 11-12 (Thu+Fri) because MealViewer published a shorter end-of-year view.
+    // isNearSchoolYearEnd('2026-06-12') → true so the forward-looking horizon check
+    // is bypassed and the two-day end-of-year snapshot is accepted.
     const previous = normalizeMenuResponse(
       {
         schoolName: 'TEST',
         menuSchedules: [
-          makeSchedule('2026-04-13', 'Lunch', PIZZA_ITEMS),
-          makeSchedule('2026-04-14', 'Lunch', PIZZA_ITEMS),
-          makeSchedule('2026-04-15', 'Lunch', PIZZA_ITEMS),
-          makeSchedule('2026-04-16', 'Lunch', PIZZA_ITEMS),
-          makeSchedule('2026-04-17', 'Lunch', PIZZA_ITEMS),
+          makeSchedule('2026-06-08', 'Lunch', PIZZA_ITEMS),
+          makeSchedule('2026-06-09', 'Lunch', PIZZA_ITEMS),
+          makeSchedule('2026-06-10', 'Lunch', PIZZA_ITEMS),
+          makeSchedule('2026-06-11', 'Lunch', PIZZA_ITEMS),
+          makeSchedule('2026-06-12', 'Lunch', PIZZA_ITEMS),
         ],
       },
-      { todayISO: '2026-04-13' },
+      { todayISO: '2026-06-11' },
     );
     const next = normalizeMenuResponse(
       {
         schoolName: 'TEST',
         menuSchedules: [
+          makeSchedule('2026-06-11', 'Lunch', PIZZA_ITEMS),
+          makeSchedule('2026-06-12', 'Lunch', PIZZA_ITEMS),
+        ],
+      },
+      { todayISO: '2026-06-11' },
+    );
+
+    expect(isPlausibleMenuSnapshot(next.days, previous.days, '2026-06-11')).toBe(true);
+  });
+
+  it('rejects a Mon+Tue snapshot mid-year when many instructional days remain in the 14-day horizon', () => {
+    // Apr 13 (Mon) + Apr 14 (Tue) with todayISO Apr 13: the 14-day horizon
+    // contains many instructional days, so this is identified as truncated data
+    // rather than a calendar-justified short week.
+    const result = normalizeMenuResponse(
+      {
+        schoolName: 'TEST',
+        menuSchedules: [
           makeSchedule('2026-04-13', 'Lunch', PIZZA_ITEMS),
           makeSchedule('2026-04-14', 'Lunch', PIZZA_ITEMS),
         ],
@@ -369,22 +391,7 @@ describe('menu-core', () => {
       { todayISO: '2026-04-13' },
     );
 
-    expect(isPlausibleMenuSnapshot(next.days, previous.days, '2026-04-13')).toBe(true);
-  });
-
-  it('accepts a shorter snapshot when only two school days remain in the visible range', () => {
-    const result = normalizeMenuResponse(
-      {
-        schoolName: 'TEST',
-        menuSchedules: [
-          makeSchedule('2026-04-16', 'Lunch', PIZZA_ITEMS),
-          makeSchedule('2026-04-17', 'Lunch', PIZZA_ITEMS),
-        ],
-      },
-      { todayISO: '2026-04-16' },
-    );
-
-    expect(isPlausibleMenuSnapshot(result.days, undefined, '2026-04-16')).toBe(true);
+    expect(isPlausibleMenuSnapshot(result.days, undefined, '2026-04-13')).toBe(false);
   });
 
   // ── formatMealViewerDate ───────────────────────────────────────────────────

--- a/shared/menu-core.ts
+++ b/shared/menu-core.ts
@@ -1,6 +1,7 @@
 import {
   countPWCSInstructionalWeekdaysBetween,
   getPWCSNoSchoolDatesBetween,
+  isNearSchoolYearEnd,
   isPWCSNoSchoolDate,
 } from './pwcs-calendar.ts';
 
@@ -171,20 +172,29 @@ function isPlausibleMenuSnapshot(
 
   // Reject if too few visible days — but allow a calendar-justified short week.
   //
+  // Uses a forward-looking 14-day horizon rather than the data's own lastVisibleISO
+  // to avoid circular reasoning: checking how many days exist in the fetched range
+  // can't tell us whether MealViewer simply published a short week or truncated data.
+  //
   // Truth table (minimumDays = 3):
   //   visibleDays.length >= 3           → outer condition false → pass
+  //   visibleDays.length < 2            → inner size check true → always fail
   //   visibleDays.length == 2:
-  //     instructional days in window < 3 → inner OR both false → pass (end-of-year)
-  //     instructional days in window >= 3 → inner right true   → fail (missing data)
-  //   visibleDays.length < 2            → inner left true      → always fail
-  if (
-    visibleDays.length < minimumDays &&
-    (
-      visibleDays.length < Math.max(2, minimumDays - 1) ||
-      countPWCSInstructionalWeekdaysBetween(getNextSchoolDay(todayISO), lastVisibleISO) >= minimumDays
-    )
-  ) {
-    return false;
+  //     near school-year end            → year-end exception   → pass
+  //     horizon has < 3 instructional   → inner count false    → pass (genuine short week)
+  //     horizon has >= 3 instructional  → inner count true     → fail (missing data)
+  if (visibleDays.length < minimumDays) {
+    if (visibleDays.length < Math.max(2, minimumDays - 1)) {
+      return false;
+    }
+    if (!isNearSchoolYearEnd(lastVisibleISO)) {
+      const horizonDate = parseISOAtUtcNoon(getNextSchoolDay(todayISO));
+      horizonDate.setUTCDate(horizonDate.getUTCDate() + 13);
+      const horizonISO = formatUTCISODate(horizonDate);
+      if (countPWCSInstructionalWeekdaysBetween(getNextSchoolDay(todayISO), horizonISO) >= minimumDays) {
+        return false;
+      }
+    }
   }
 
   if (!previousDays) {
@@ -513,4 +523,5 @@ export {
   getTodayISO,
   normalizeMealViewerDay,
   normalizeMenuResponse,
+  normalizeVisibleSharedDays,
 };

--- a/shared/menu-core.ts
+++ b/shared/menu-core.ts
@@ -69,14 +69,23 @@ const schoolDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: '2-digit',
 });
 
+// Lazy cache of formatters keyed by JSON-stringified options.  DayCard and
+// DayTabs call formatSchoolDate with a small fixed set of option shapes
+// (≈4 distinct combinations), so this cache converges quickly and avoids
+// allocating a new Intl.DateTimeFormat on every render cycle.
+const schoolDateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
 function formatSchoolDate(
   iso: string,
   options: Intl.DateTimeFormatOptions,
 ): string {
-  return new Intl.DateTimeFormat('en-US', {
-    ...options,
-    timeZone: SCHOOL_TIMEZONE,
-  }).format(parseISOAtUtcNoon(iso));
+  const cacheKey = JSON.stringify(options);
+  let formatter = schoolDateFormatterCache.get(cacheKey);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', { ...options, timeZone: SCHOOL_TIMEZONE });
+    schoolDateFormatterCache.set(cacheKey, formatter);
+  }
+  return formatter.format(parseISOAtUtcNoon(iso));
 }
 
 function getTodayISO(): string {

--- a/shared/pwcs-calendar.ts
+++ b/shared/pwcs-calendar.ts
@@ -64,6 +64,21 @@ const PWCS_NO_SCHOOL_RANGES: NoSchoolDateRange[] = [
 
 const PWCS_CALENDAR_COVERAGE_END_ISO = '2027-06-21';
 
+// The last instructional day of each covered school year.  Used by
+// isNearSchoolYearEnd to allow short snapshots in the final days of school
+// without triggering the forward-looking plausibility guard.
+const PWCS_SCHOOL_YEAR_LAST_DAYS = ['2026-06-12', '2027-06-17'];
+
+function isNearSchoolYearEnd(iso: string, windowDays = 5): boolean {
+  const date = parseISOAtUtcNoon(iso);
+  return PWCS_SCHOOL_YEAR_LAST_DAYS.some((lastDay) => {
+    const last = parseISOAtUtcNoon(lastDay);
+    const diffMs = last.getTime() - date.getTime();
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+    return diffDays >= 0 && diffDays <= windowDays;
+  });
+}
+
 function expandDateRange({ start, end = start }: NoSchoolDateRange): string[] {
   const dates: string[] = [];
   const cursor = parseISOAtUtcNoon(start);
@@ -131,7 +146,9 @@ function countPWCSInstructionalWeekdaysBetween(startISO: string, endISO: string)
 export {
   countPWCSInstructionalWeekdaysBetween,
   getPWCSNoSchoolDatesBetween,
+  isNearSchoolYearEnd,
   isPWCSNoSchoolDate,
   PWCS_CALENDAR_COVERAGE_END_ISO,
   PWCS_NO_SCHOOL_DATES,
+  PWCS_SCHOOL_YEAR_LAST_DAYS,
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,8 +81,10 @@ function App() {
   const [retrying, setRetrying] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [themePreference, setThemePreference] = useState<ThemePreference>(getInitialThemePreference);
-  // Derive the concrete theme from the same preference: reads localStorage once
-  // via getInitialThemePreference() then converts 'system' to the OS value.
+  // Derive the concrete theme from the stored preference, converting 'system'
+  // to the actual OS value via getSystemTheme().  getInitialThemePreference()
+  // is called a second time here (two localStorage reads on mount) because
+  // useState does not expose its lazy-init result to sibling useState calls.
   const [theme, setTheme] = useState<Theme>(() => getInitialTheme(getInitialThemePreference()));
   const retryControllerRef = useRef<AbortController | null>(null);
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -9,6 +9,8 @@ describe('api', () => {
   beforeEach(() => {
     const storage = new Map<string, string>();
     vi.stubGlobal('localStorage', {
+      get length() { return storage.size; },
+      key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
       getItem: vi.fn((key: string) => storage.get(key) ?? null),
       setItem: vi.fn((key: string, value: string) => {
         storage.set(key, value);
@@ -483,6 +485,8 @@ describe('api', () => {
     };
 
     vi.stubGlobal('localStorage', {
+      get length() { return 1; },
+      key: vi.fn(() => null),
       getItem: vi.fn(() => JSON.stringify(cachedPayload)),
       setItem: vi.fn(),
       removeItem: vi.fn(),
@@ -490,11 +494,18 @@ describe('api', () => {
     });
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
 
-    const data = await getFreshData({ cacheBustKey: 'retry' });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-15T14:00:00.000Z'));
 
-    expect(data.days[0].sections[0].items).toContain('Cached Pizza');
-    expect(data.meta.source).toBe('offline');
-    expect(data.meta.isOffline).toBe(true);
+    try {
+      const data = await getFreshData({ cacheBustKey: 'retry' });
+
+      expect(data.days[0].sections[0].items).toContain('Cached Pizza');
+      expect(data.meta.source).toBe('offline');
+      expect(data.meta.isOffline).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('labels cached last-known-good data distinctly when the published snapshot is unavailable', async () => {
@@ -783,6 +794,22 @@ describe('api', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('removes stale-version cache keys on first load without touching the current key', async () => {
+    // Seed one stale key (v1) and one current key.  The current key stores a
+    // wrong-version payload so loadCache returns null without removing it — this
+    // isolates the purge assertion from the self-healing removeItem that loadCache
+    // performs on corrupt entries.
+    const staleKey = 'bms_lunch_cache_v1';
+    const currentKey = `bms_lunch_cache_v${MENU_CACHE_SEMANTIC_VERSION}`;
+    localStorage.setItem(staleKey, '{}');
+    localStorage.setItem(currentKey, JSON.stringify({ version: 0 })); // wrong version → returns null, no remove
+
+    await getCachedData();
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith(staleKey);
+    expect(localStorage.removeItem).not.toHaveBeenCalledWith(currentKey);
   });
 
   it('labels cached last-known-good data distinctly when the published snapshot is invalid', async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,7 +14,6 @@ import type { MenuData } from './types';
 
 const CACHE_KEY = `bms_lunch_cache_v${MENU_CACHE_SEMANTIC_VERSION}`;
 const CACHE_KEY_PREFIX = 'bms_lunch_cache_v';
-const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const SNAPSHOT_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // weekly schedule SLA
 const INVALID_SNAPSHOT_MESSAGE = 'Menu snapshot is unavailable right now. Showing the last known good menu.';
 const INVALID_NO_CACHE_MESSAGE = 'Menu snapshot is invalid right now. Please try again later.';
@@ -79,16 +78,12 @@ function normalizeVisibleDays(days: MenuData['days'], todayISO = getTodayISO()):
     }));
 }
 
-function isSnapshotStale(snapshotGeneratedAt?: string, fallbackFetchedAt?: number): boolean {
+function isSnapshotStale(snapshotGeneratedAt?: string): boolean {
   if (snapshotGeneratedAt) {
     const generatedAt = Date.parse(snapshotGeneratedAt);
     if (Number.isFinite(generatedAt)) {
       return Date.now() - generatedAt > SNAPSHOT_STALE_AFTER_MS;
     }
-  }
-
-  if (typeof fallbackFetchedAt === 'number') {
-    return Date.now() - fallbackFetchedAt > CACHE_TTL_MS;
   }
 
   return false;
@@ -105,7 +100,7 @@ function finalizeMenuData(
   const isStale = overrides?.isStale ??
     (expectedNextRefreshAt && isPastExpectedRefresh(expectedNextRefreshAt)
       ? true
-      : isSnapshotStale(snapshotGeneratedAt, clientFetchedAt));
+      : isSnapshotStale(snapshotGeneratedAt));
 
   return {
     ...data,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,8 @@
 import {
-  getNextSchoolDay,
   getTodayISO,
   isPlausibleMenuSnapshot,
   MENU_SCHEMA_VERSION,
+  normalizeVisibleSharedDays,
   SCHOOL_ID,
 } from '../shared/menu-core.js';
 import {
@@ -68,16 +68,6 @@ function getMenuDataUrl(cacheBustKey?: string): string {
   return `${import.meta.env.BASE_URL}menu-data.json?v=${encodeURIComponent(version)}`;
 }
 
-function normalizeVisibleDays(days: MenuData['days'], todayISO = getTodayISO()): MenuData['days'] {
-  const displayFromISO = getNextSchoolDay(todayISO);
-  return days
-    .filter((day) => !day.weekend && day.iso >= displayFromISO)
-    .map((day) => ({
-      ...day,
-      today: day.iso === todayISO,
-    }));
-}
-
 function isSnapshotStale(snapshotGeneratedAt?: string): boolean {
   if (snapshotGeneratedAt) {
     const generatedAt = Date.parse(snapshotGeneratedAt);
@@ -93,7 +83,7 @@ function finalizeMenuData(
   data: MenuData,
   overrides?: Partial<MenuData['meta']>,
 ): MenuData {
-  const visibleDays = normalizeVisibleDays(data.days);
+  const visibleDays = normalizeVisibleSharedDays(data.days);
   const snapshotGeneratedAt = overrides?.snapshotGeneratedAt ?? data.meta.snapshotGeneratedAt;
   const expectedNextRefreshAt = overrides?.expectedNextRefreshAt ?? data.meta.expectedNextRefreshAt;
   const clientFetchedAt = overrides?.clientFetchedAt ?? data.meta.clientFetchedAt;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,10 +31,11 @@ export interface MenuData {
     expectedNextRefreshAt?: string;
     /**
      * Unix epoch ms recorded when the browser saved this payload to the local
-     * cache.  Used to enforce the 4-hour TTL and to display "cached X ago".
+     * cache.  Used to determine staleness against the weekly refresh schedule
+     * and to compute the 7-day absolute stale ceiling.
      */
     clientFetchedAt?: number;
-    /** True when the cached entry is older than the 4-hour TTL. */
+    /** True when the cached entry is past the expected weekly refresh time or the 7-day absolute ceiling. */
     isStale?: boolean;
     isOffline: boolean;
     isPreview: boolean;


### PR DESCRIPTION
## Summary

- **`types.ts`**: Corrected stale JSDoc on `clientFetchedAt` and `isStale` to describe the weekly-refresh-schedule staleness model instead of the removed 4-hour TTL
- **`pwcs-calendar.ts`**: Added `PWCS_SCHOOL_YEAR_LAST_DAYS` and `isNearSchoolYearEnd()` to distinguish end-of-year short weeks from truncated mid-year data
- **`menu-core.ts`**: Replaced circular `countPWCS(today, lastVisible)` plausibility guard with a forward-looking 14-day horizon check plus year-end bypass; exported `normalizeVisibleSharedDays`
- **`menu-core.test.ts`**: Updated two tests that relied on buggy circular behavior; added rejection test for Mon+Tue mid-year snapshot
- **`api.ts`**: Removed duplicate `normalizeVisibleDays`, now uses shared `normalizeVisibleSharedDays` from menu-core
- **`fetch-menu.ts`**: Added high-noInfo-rate guard (>50% noInfo with >40pp jump vs previous snapshot) to catch MealViewer partial-data regressions; added 30s fetch timeout with AbortController
- **`fetch-menu.yml`**: Added `git pull --rebase origin main` before push to prevent race-condition push failures

73/73 tests pass.

## Test plan

- [ ] All 73 tests pass (`npm test`)
- [ ] Plausibility: Mon+Tue mid-year snapshot is rejected; Jun 11-12 end-of-year snapshot is accepted
- [ ] `normalizeVisibleSharedDays` import resolves correctly in `api.ts`
- [ ] Workflow `git pull --rebase` prevents push conflicts on concurrent runs