### PR TITLE
Add swipe transitions, last-day confetti, and countdown flip animation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -489,6 +489,65 @@ main {
   }
 }
 
+/* ── Day card slide transitions ── */
+.day-card.slide-in-left {
+  animation: slideInLeft 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+.day-card.slide-in-right {
+  animation: slideInRight 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+@keyframes slideInLeft {
+  from { transform: translateX(55px); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+
+@keyframes slideInRight {
+  from { transform: translateX(-55px); opacity: 0; }
+  to   { transform: translateX(0);     opacity: 1; }
+}
+
+/* ── Countdown flip animation ── */
+.school-countdown {
+  perspective: 300px;
+}
+
+.school-countdown-value.flipping {
+  animation: flipCount 0.38s ease-in-out;
+}
+
+@keyframes flipCount {
+  0%   { transform: rotateX(0deg);   opacity: 1; }
+  40%  { transform: rotateX(90deg);  opacity: 0; }
+  60%  { transform: rotateX(-90deg); opacity: 0; }
+  100% { transform: rotateX(0deg);   opacity: 1; }
+}
+
+/* ── Confetti ── */
+.confetti-container {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 50;
+  overflow: hidden;
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -20px;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  animation: confettiFall linear forwards;
+}
+
+@keyframes confettiFall {
+  0%   { transform: translateY(0) rotate(0deg);     opacity: 1; }
+  80%  { opacity: 1; }
+  100% { transform: translateY(110vh) rotate(720deg); opacity: 0; }
+}
+
 /* ── Reduced motion ── */
 @media (prefers-reduced-motion: reduce) {
   * {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getCachedData, getFreshData } from './api';
 import { MENU_SCHEMA_VERSION, SCHOOL_ID, SCHOOL_TIMEZONE } from '../shared/menu-core.js';
 import type { MenuData } from './types';
@@ -86,7 +86,9 @@ function App() {
   // is called a second time here (two localStorage reads on mount) because
   // useState does not expose its lazy-init result to sibling useState calls.
   const [theme, setTheme] = useState<Theme>(() => getInitialTheme(getInitialThemePreference()));
+  const [swipeDirection, setSwipeDirection] = useState<'left' | 'right' | null>(null);
   const retryControllerRef = useRef<AbortController | null>(null);
+  const touchStartXRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (themePreference === 'system') {
@@ -250,6 +252,27 @@ function App() {
     setSelectedIndex((i) => Math.min(i, Math.max(days.length - 1, 0)));
   }, [days.length]);
 
+  const handleSelectDay = useCallback((newIndex: number) => {
+    setSwipeDirection(newIndex > selectedIndex ? 'left' : 'right');
+    setSelectedIndex(newIndex);
+  }, [selectedIndex]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartXRef.current = e.touches[0].clientX;
+  }, []);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (touchStartXRef.current === null) return;
+    const delta = e.changedTouches[0].clientX - touchStartXRef.current;
+    touchStartXRef.current = null;
+    if (Math.abs(delta) < 40) return;
+    if (delta < 0 && selectedIndex < days.length - 1) {
+      handleSelectDay(selectedIndex + 1);
+    } else if (delta > 0 && selectedIndex > 0) {
+      handleSelectDay(selectedIndex - 1);
+    }
+  }, [selectedIndex, days.length, handleSelectDay]);
+
   const nextTheme = theme === 'dark' ? 'light' : 'dark';
 
   return (
@@ -287,14 +310,18 @@ function App() {
         <DayTabs
           days={days}
           selectedIndex={selectedIndex}
-          onSelect={setSelectedIndex}
+          onSelect={handleSelectDay}
         />
       )}
 
-      <main>
+      <main onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
         {loading && <SkeletonLoader />}
         {!loading && days.length > 0 && days[selectedIndex] && (
-          <DayCard day={days[selectedIndex]} />
+          <DayCard
+            key={selectedIndex}
+            day={days[selectedIndex]}
+            direction={swipeDirection}
+          />
         )}
         {!loading && days.length === 0 && (
           <div className="empty-state">

--- a/src/components/Confetti.tsx
+++ b/src/components/Confetti.tsx
@@ -1,0 +1,38 @@
+import React, { useMemo } from 'react';
+
+const COLORS = ['#3b82f6', '#f59e0b', '#ef4444', '#10b981', '#a855f7', '#ec4899', '#f97316'];
+const PIECE_COUNT = 48;
+
+export const Confetti: React.FC = () => {
+  const pieces = useMemo(() =>
+    Array.from({ length: PIECE_COUNT }, (_, i) => ({
+      id: i,
+      left: `${Math.random() * 100}%`,
+      color: COLORS[i % COLORS.length],
+      size: `${6 + Math.random() * 8}px`,
+      duration: `${2.2 + Math.random() * 2}s`,
+      delay: `${Math.random() * 1.8}s`,
+      borderRadius: Math.random() > 0.5 ? '50%' : '2px',
+    })), []
+  );
+
+  return (
+    <div className="confetti-container" aria-hidden="true">
+      {pieces.map((p) => (
+        <span
+          key={p.id}
+          className="confetti-piece"
+          style={{
+            left: p.left,
+            backgroundColor: p.color,
+            width: p.size,
+            height: p.size,
+            borderRadius: p.borderRadius,
+            animationDuration: p.duration,
+            animationDelay: p.delay,
+          }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/DayCard.tsx
+++ b/src/components/DayCard.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { MenuDay } from '../types';
 import { formatSchoolDate } from '../../shared/menu-core.js';
 import { PWCS_SCHOOL_YEAR_LAST_DAYS } from '../../shared/pwcs-calendar.js';
+import { Confetti } from './Confetti';
 
 interface Props {
   day: MenuDay;
+  direction?: 'left' | 'right' | null;
 }
 
 const COUNTDOWN_START_ISO = '2026-05-01';
@@ -43,13 +45,54 @@ function getSchoolCountdownDays(iso: string): number | null {
   return Math.max(0, Math.round((getUtcDay(lastDayOfSchool) - getUtcDay(iso)) / MS_PER_DAY));
 }
 
-export const DayCard: React.FC<Props> = ({ day }) => {
+export const DayCard: React.FC<Props> = ({ day, direction }) => {
   const weekday = formatSchoolDate(day.iso, { weekday: 'long' });
   const shortDate = formatSchoolDate(day.iso, {
     month: 'short',
     day: 'numeric',
   });
   const countdownDays = getSchoolCountdownDays(day.iso);
+
+  // Countdown flip animation
+  const prevCountdown = useRef<number | null | undefined>(undefined);
+  const [isFlipping, setIsFlipping] = useState(false);
+
+  useEffect(() => {
+    if (prevCountdown.current !== undefined && prevCountdown.current !== countdownDays) {
+      setIsFlipping(true);
+      const id = setTimeout(() => setIsFlipping(false), 400);
+      return () => clearTimeout(id);
+    }
+    prevCountdown.current = countdownDays;
+  }, [countdownDays]);
+
+  const slideClass = direction === 'left' ? 'slide-in-left' : direction === 'right' ? 'slide-in-right' : '';
+
+  const isLastDay = countdownDays === 0;
+
+  const countdownWidget = countdownDays !== null && (
+    isLastDay ? (
+      <div
+        className="school-countdown"
+        aria-label="Last day of school!"
+      >
+        <span className="school-countdown-label">Today is</span>
+        <span className="school-countdown-value" style={{ fontSize: 'clamp(15px, 4vw, 20px)' }}>🎉</span>
+        <span className="school-countdown-unit">Last Day!</span>
+      </div>
+    ) : (
+      <div
+        className="school-countdown"
+        aria-label={`${countdownDays} days until the last day of school`}
+      >
+        <span className="school-countdown-label">School's out in</span>
+        <span className={`school-countdown-value${isFlipping ? ' flipping' : ''}`}>{countdownDays}</span>
+        <span className="school-countdown-unit">
+          {countdownDays === 1 ? 'day' : 'days'}
+        </span>
+      </div>
+    )
+  );
 
   const dayHead = (
     <div className="day-head">
@@ -58,26 +101,14 @@ export const DayCard: React.FC<Props> = ({ day }) => {
         <span className="day-weekday">{weekday}</span>
         <span className="day-name">{shortDate}</span>
       </div>
-      {countdownDays !== null && (
-        <div
-          className="school-countdown"
-          aria-label={`${countdownDays} days until the last day of school`}
-        >
-          <span className="school-countdown-label">School's out in</span>
-          <span className="school-countdown-value">{countdownDays}</span>
-          <span className="school-countdown-unit">
-            {countdownDays === 1 ? 'day' : 'days'}
-          </span>
-        </div>
-      )}
+      {countdownWidget}
     </div>
   );
 
-  // Check no_school first: a no-school day always has empty sections, so
-  // checking no_information_provided first would swallow the "No school" UI.
   if (day.no_school) {
     return (
-      <div className="day-card">
+      <div className={`day-card ${slideClass}`}>
+        {isLastDay && <Confetti />}
         {dayHead}
         <div className="empty-state">
           <h2>No school</h2>
@@ -89,7 +120,8 @@ export const DayCard: React.FC<Props> = ({ day }) => {
 
   if (day.no_information_provided) {
     return (
-      <div className="day-card">
+      <div className={`day-card ${slideClass}`}>
+        {isLastDay && <Confetti />}
         {dayHead}
         <div className="empty-state">
           <h2>No menu yet</h2>
@@ -106,7 +138,8 @@ export const DayCard: React.FC<Props> = ({ day }) => {
     : sections.slice();
 
   return (
-    <div className="day-card">
+    <div className={`day-card ${slideClass}`}>
+      {isLastDay && <Confetti />}
       {dayHead}
 
       {entreeSection && (


### PR DESCRIPTION
## Summary

- **Swipe navigation** — swipe left/right on the day card to browse days with a directional slide-in animation; tab taps animate in the matching direction
- **Last Day confetti** — when the school-year countdown hits 0, 48 colorful confetti pieces rain down the screen and the countdown widget shows "🎉 Last Day!"
- **Countdown flip** — the "days left" number does a mechanical scoreboard flip each time it changes as you browse days

## Test plan

- [ ] Open on mobile (or Chrome DevTools device emulation) and swipe left/right on the day card — cards should slide in from the correct direction
- [ ] Tap day tabs — animation direction should match (forward = slide left, back = slide right)
- [ ] Temporarily set `COUNTDOWN_START_ISO` or `countdownDays` to `0` in `DayCard.tsx` to verify confetti fires and the widget shows "Last Day!"
- [ ] Browse multiple days and confirm the countdown number flips each time it changes
- [ ] Run `npm test` — all 80 tests should pass
- [ ] Run `npm run typecheck` — no errors

https://claude.ai/code/session_01WfszwTV7rmkTS6N5ptFS6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfszwTV7rmkTS6N5ptFS6b)_