### PR TITLE
Fix iOS PWA swipe + staggered section entrance + today-tab pulse glow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -489,6 +489,27 @@ main {
   }
 }
 
+/* ── Section stagger entrance ── */
+.entree-block,
+.section-block {
+  animation: sectionFadeIn 0.3s ease both;
+}
+
+@keyframes sectionFadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0);   }
+}
+
+/* ── Today tab pulse glow ── */
+.day-chip.today:not(.active) {
+  animation: todayPulse 2.4s ease-in-out infinite;
+}
+
+@keyframes todayPulse {
+  0%, 100% { box-shadow: none; }
+  50%       { box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.28), 0 0 14px rgba(59, 130, 246, 0.14); }
+}
+
 /* ── Day card slide transitions ── */
 .day-card.slide-in-left {
   animation: slideInLeft 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,7 +88,9 @@ function App() {
   const [theme, setTheme] = useState<Theme>(() => getInitialTheme(getInitialThemePreference()));
   const [swipeDirection, setSwipeDirection] = useState<'left' | 'right' | null>(null);
   const retryControllerRef = useRef<AbortController | null>(null);
-  const touchStartXRef = useRef<number | null>(null);
+  const mainRef = useRef<HTMLElement>(null);
+  const selectedIndexRef = useRef(0);
+  const daysLengthRef = useRef(0);
 
   useEffect(() => {
     if (themePreference === 'system') {
@@ -257,21 +259,60 @@ function App() {
     setSelectedIndex(newIndex);
   }, [selectedIndex]);
 
-  const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    touchStartXRef.current = e.touches[0].clientX;
-  }, []);
+  // Sync refs so the stable touch-listener effect always reads current values.
+  selectedIndexRef.current = selectedIndex;
+  daysLengthRef.current = days.length;
 
-  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
-    if (touchStartXRef.current === null) return;
-    const delta = e.changedTouches[0].clientX - touchStartXRef.current;
-    touchStartXRef.current = null;
-    if (Math.abs(delta) < 40) return;
-    if (delta < 0 && selectedIndex < days.length - 1) {
-      handleSelectDay(selectedIndex + 1);
-    } else if (delta > 0 && selectedIndex > 0) {
-      handleSelectDay(selectedIndex - 1);
-    }
-  }, [selectedIndex, days.length, handleSelectDay]);
+  // Raw DOM listeners with { passive: false } so we can call preventDefault()
+  // on horizontal swipes — required for iOS PWA where the scrollable DayCard
+  // child swallows synthetic React touch events before they reach <main>.
+  useEffect(() => {
+    const el = mainRef.current;
+    if (!el) return;
+
+    let startX = 0;
+    let startY = 0;
+    let isHorizontal: boolean | null = null;
+
+    const onStart = (e: TouchEvent) => {
+      startX = e.touches[0].clientX;
+      startY = e.touches[0].clientY;
+      isHorizontal = null;
+    };
+
+    const onMove = (e: TouchEvent) => {
+      if (isHorizontal === null) {
+        const dx = Math.abs(e.touches[0].clientX - startX);
+        const dy = Math.abs(e.touches[0].clientY - startY);
+        if (dx > 6 || dy > 6) isHorizontal = dx > dy;
+      }
+      if (isHorizontal) e.preventDefault();
+    };
+
+    const onEnd = (e: TouchEvent) => {
+      if (!isHorizontal) return;
+      const delta = e.changedTouches[0].clientX - startX;
+      if (Math.abs(delta) < 40) return;
+      const idx = selectedIndexRef.current;
+      const len = daysLengthRef.current;
+      if (delta < 0 && idx < len - 1) {
+        setSwipeDirection('left');
+        setSelectedIndex(idx + 1);
+      } else if (delta > 0 && idx > 0) {
+        setSwipeDirection('right');
+        setSelectedIndex(idx - 1);
+      }
+    };
+
+    el.addEventListener('touchstart', onStart, { passive: true });
+    el.addEventListener('touchmove', onMove, { passive: false });
+    el.addEventListener('touchend', onEnd, { passive: true });
+    return () => {
+      el.removeEventListener('touchstart', onStart);
+      el.removeEventListener('touchmove', onMove);
+      el.removeEventListener('touchend', onEnd);
+    };
+  }, []); // stable: setState setters never change; current values read via refs
 
   const nextTheme = theme === 'dark' ? 'light' : 'dark';
 
@@ -314,7 +355,7 @@ function App() {
         />
       )}
 
-      <main onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+      <main ref={mainRef}>
         {loading && <SkeletonLoader />}
         {!loading && days.length > 0 && days[selectedIndex] && (
           <DayCard

--- a/src/components/DayCard.tsx
+++ b/src/components/DayCard.tsx
@@ -143,7 +143,10 @@ export const DayCard: React.FC<Props> = ({ day, direction }) => {
       {dayHead}
 
       {entreeSection && (
-        <div className={`entree-block ${entreeSection.items.length >= 3 ? 'featured' : 'compact'}`}>
+        <div
+          className={`entree-block ${entreeSection.items.length >= 3 ? 'featured' : 'compact'}`}
+          style={{ animationDelay: '0ms' }}
+        >
           <div className="sec-label">{getCategoryEmoji('Entree')} Entree</div>
           <ul>
             {entreeSection.items.map((item) => (
@@ -154,9 +157,13 @@ export const DayCard: React.FC<Props> = ({ day, direction }) => {
       )}
 
       <div className="sections-rest">
-        {restSections.map((section) => {
+        {restSections.map((section, i) => {
           return (
-            <div key={section.title} className={`section-block ${section.wide ? 'wide' : 'compact'}`}>
+            <div
+              key={section.title}
+              className={`section-block ${section.wide ? 'wide' : 'compact'}`}
+              style={{ animationDelay: `${(i + 1) * 55}ms` }}
+            >
               <div className="sec-label">{getCategoryEmoji(section.title)} {section.title}</div>
               <ul>
                 {section.items.map((item) => (


### PR DESCRIPTION
## Summary

- **iOS PWA swipe fix** — swipe left/right now works when the app is added to the iPhone Home Screen. Root cause was iOS capturing touch events before React could see them; fixed with raw DOM listeners (`{ passive: false }` on `touchmove`) that detect horizontal vs. vertical intent and call `preventDefault()` only for horizontal swipes
- **Staggered section entrance** — each menu section block fades up with a 55ms cascade delay when a new day loads, so the card content fans in like a deck of cards
- **Today tab pulse glow** — the current-day chip in the tab bar breathes a slow blue glow (2.4s infinite) so today always draws the eye

## Test plan

- [ ] Add app to iPhone Home Screen → swipe left/right to change days (this was broken before)
- [ ] Switch days — section blocks should cascade in one by one
- [ ] Find today's tab chip — should have a soft pulsing blue glow
- [ ] Vertical scroll on a day with long menus still works (swipe fix must not block scroll)
- [ ] Run `npm test` — all 80 tests pass

https://claude.ai/code/session_01WfszwTV7rmkTS6N5ptFS6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfszwTV7rmkTS6N5ptFS6b)_