### PR TITLE
Add frosted glass depth to section and entree cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,10 @@
   --toggle-fg: #ffffff;
   --toggle-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
   --list-text: rgba(255, 255, 255, 0.75);
+  --card-bg: rgba(255, 255, 255, 0.065);
+  --card-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.09),
+                 0 2px 8px rgba(0, 0, 0, 0.20),
+                 0 8px 24px rgba(0, 0, 0, 0.12);
 }
 
 :root[data-theme='light'] {
@@ -30,6 +34,10 @@
   --toggle-fg: #111111;
   --toggle-shadow: 0 10px 30px rgba(59, 130, 246, 0.12);
   --list-text: rgba(0, 0, 0, 0.72);
+  --card-bg: rgba(255, 255, 255, 0.82);
+  --card-shadow: inset 0 1px 0 rgba(255, 255, 255, 1),
+                 0 1px 3px rgba(0, 0, 0, 0.05),
+                 0 4px 14px rgba(0, 0, 0, 0.08);
 }
 
 /* ── Reset ── */
@@ -302,11 +310,17 @@ main {
   padding: 12px clamp(12px, 3vw, 16px);
   border: 1px solid var(--line);
   border-radius: 18px;
-  background: var(--surface);
+  background: var(--card-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: var(--card-shadow);
 }
 
 .entree-block.featured {
-  background: linear-gradient(180deg, var(--surface-strong), var(--surface-soft));
+  background: linear-gradient(160deg,
+    color-mix(in srgb, var(--c) 12%, var(--card-bg)),
+    var(--card-bg)
+  );
 }
 
 .entree-block.compact {
@@ -364,8 +378,11 @@ main {
 .section-block {
   padding: 11px clamp(10px, 2.5vw, 14px);
   border-radius: 16px;
-  background: var(--surface);
+  background: var(--card-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   border: 1px solid var(--line);
+  box-shadow: var(--card-shadow);
   min-width: 0;
   overflow: hidden;
 }
@@ -503,7 +520,7 @@ header,
 .entree-block,
 .school-countdown {
   transition: background 0.4s ease, background-color 0.4s ease,
-              border-color 0.4s ease, color 0.4s ease;
+              border-color 0.4s ease, color 0.4s ease, box-shadow 0.4s ease;
 }
 
 /* ── Section stagger entrance ── */


### PR DESCRIPTION
## Summary

Cards go from nearly-invisible transparent surfaces to proper frosted glass panels:

- **`--card-bg`** raises surface opacity from ~3% → ~6.5% in dark mode, and to ~82% white in light mode — cards now read as distinct layers floating above the background
- **`backdrop-filter: blur(8px)`** gives each card a frosted glass texture
- **`box-shadow`** layered effect: an inset top-edge highlight simulates light catching the rim, plus a two-layer outer shadow for lift and depth
- **`.entree-block.featured`** uses `color-mix()` to blend a 12% blue tint into the card background — subtle branded gradient on the entree block when there are 3+ items
- **Theme crossfade** updated to include `box-shadow` so shadows melt smoothly when toggling dark/light

## Test plan

- [ ] Dark mode: section cards should feel elevated with visible shadows and a faint top-edge shimmer
- [ ] Light mode: cards should look like white frosted glass panels with soft drop shadows
- [ ] Toggle dark↔light: shadows and backgrounds should crossfade smoothly
- [ ] All 80 tests pass

https://claude.ai/code/session_01WfszwTV7rmkTS6N5ptFS6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfszwTV7rmkTS6N5ptFS6b)_