### PR TITLE
Auto-select today, tap press feedback, no-school week screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -520,7 +520,44 @@ header,
 .entree-block,
 .school-countdown {
   transition: background 0.4s ease, background-color 0.4s ease,
-              border-color 0.4s ease, color 0.4s ease, box-shadow 0.4s ease;
+              border-color 0.4s ease, color 0.4s ease, box-shadow 0.4s ease,
+              transform 0.1s ease;
+}
+
+/* ── Tap press feedback ── */
+.section-block:active,
+.entree-block:active {
+  transform: scale(0.97);
+}
+
+/* ── No school / summer mode ── */
+.no-school-week {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  text-align: center;
+  gap: 12px;
+}
+
+.no-school-emoji {
+  font-size: clamp(56px, 16vw, 80px);
+  line-height: 1;
+  animation: sunPulse 3s ease-in-out infinite;
+}
+
+.no-school-title {
+  font-size: clamp(22px, 6vw, 28px);
+  font-weight: 900;
+  letter-spacing: -0.5px;
+  margin: 0;
+}
+
+@keyframes sunPulse {
+  0%, 100% { transform: scale(1)    rotate(-4deg); }
+  50%       { transform: scale(1.1) rotate(4deg);  }
 }
 
 /* ── Section stagger entrance ── */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,7 @@ function App() {
   const mainRef = useRef<HTMLElement>(null);
   const selectedIndexRef = useRef(0);
   const daysLengthRef = useRef(0);
+  const autoSelectedRef = useRef(false);
 
   useEffect(() => {
     if (themePreference === 'system') {
@@ -254,6 +255,14 @@ function App() {
     setSelectedIndex((i) => Math.min(i, Math.max(days.length - 1, 0)));
   }, [days.length]);
 
+  // Jump to today's day on first data load
+  useEffect(() => {
+    if (autoSelectedRef.current || days.length === 0) return;
+    autoSelectedRef.current = true;
+    const todayIndex = days.findIndex((d) => d.today);
+    if (todayIndex >= 0) setSelectedIndex(todayIndex);
+  }, [days.length]);
+
   const handleSelectDay = useCallback((newIndex: number) => {
     setSwipeDirection(newIndex > selectedIndex ? 'left' : 'right');
     setSelectedIndex(newIndex);
@@ -319,6 +328,7 @@ function App() {
     };
   }, []); // stable: setState setters never change; current values read via refs
 
+  const allNoSchool = days.length >= 3 && days.every((d) => d.no_school);
   const nextTheme = theme === 'dark' ? 'light' : 'dark';
 
   return (
@@ -352,7 +362,7 @@ function App() {
         </button>
       </header>
 
-      {!loading && days.length > 0 && (
+      {!loading && days.length > 0 && !allNoSchool && (
         <DayTabs
           days={days}
           selectedIndex={selectedIndex}
@@ -362,7 +372,14 @@ function App() {
 
       <main ref={mainRef}>
         {loading && <SkeletonLoader />}
-        {!loading && days.length > 0 && days[selectedIndex] && (
+        {!loading && allNoSchool && (
+          <div className="no-school-week">
+            <span className="no-school-emoji">☀️</span>
+            <h2 className="no-school-title">No School This Week</h2>
+            <p className="sub">Enjoy the break — see you when school's back!</p>
+          </div>
+        )}
+        {!loading && days.length > 0 && !allNoSchool && days[selectedIndex] && (
           <DayCard
             key={selectedIndex}
             day={days[selectedIndex]}


### PR DESCRIPTION
## Summary

- **Auto-select today** — on first data load the app now jumps to today's day automatically instead of always opening on day 1 (Monday). Uses a one-time ref guard so manual navigation isn't overridden on data refresh.

- **Tap press feedback** — `.section-block` and `.entree-block` scale to 0.97× on `:active`. One CSS rule. Makes every card feel physical and responsive on touch.

- **No-school week screen** — when 3+ consecutive days are all `no_school` (holiday week, snow week, summer break), the day tabs are hidden and a centred ☀️ screen appears with a gently rocking sun animation. A single no-school day (normal holiday) still shows the regular day card with the "No school" message.

## Test plan

- [ ] Open app on a weekday — should land on today, not Monday
- [ ] Tap any section card — should feel like it presses in slightly
- [ ] All 80 tests pass

https://claude.ai/code/session_01WfszwTV7rmkTS6N5ptFS6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfszwTV7rmkTS6N5ptFS6b)_